### PR TITLE
feat(tpm): add id from vtg emmc chip to use no tpm authentication

### DIFF
--- a/asserts/tpm.go
+++ b/asserts/tpm.go
@@ -253,7 +253,7 @@ func getDriveSerial(drive string) (serial string, err error) {
 	}
 
 	// this is a list of known devices that can be used for TPM ... more can be added as needed
-	if model != "Q2J55L" && model != "DG4008" && model != "JB1Q5" {
+	if model != "Q2J55L" && model != "DG4008" && model != "JB1Q5" && model != "DA6032" {
 		return "", fmt.Errorf("tpm:getDriveSerial() ID_NAME -> unknown block device model '%s'", model)
 	}
 


### PR DESCRIPTION

Add eMMC chip id from VTG device